### PR TITLE
Load Leaflet CSS via CDN link for reliable map rendering

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,5 +1,3 @@
-@import "leaflet/dist/leaflet.css";
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/app/layout.js
+++ b/app/layout.js
@@ -8,6 +8,14 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
+      <head>
+        <link
+          rel="stylesheet"
+          href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+          crossOrigin=""
+        />
+      </head>
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
The @import in globals.css may not resolve correctly across all build environments. Using a CDN link tag in layout.js is the most reliable way to ensure Leaflet CSS loads before the map renders.

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt