### PR TITLE
Redesign heart and lightning shapes for recognizable GPS art

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -63,7 +63,7 @@ export default function Home() {
           </div>
         </div>
         <div className="text-xs text-white/20 font-mono">
-          🏃 Running · 5–7 mi
+          🏃 Running · 3–5 mi
         </div>
       </header>
 

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -58,109 +58,171 @@ export const SLU_ROADS = {
 export const ROUTES = {
   heart: {
     name: "Heart",
-    dist: "5.2 mi",
-    time: "~50 min",
-    start: "Dexter Ave N & Mercer St",
-    startCoord: [MERCER, DEXTER],
+    dist: "3.6 mi",
+    time: "~35 min",
+    start: "Denny Way & Terry Ave N",
+    startCoord: [DENNY, TERRY],
     turns: [
-      { icon: "▲", text: "Start at Dexter Ave N & Mercer St — head north on Dexter Ave N" },
-      { icon: "→", text: "Continue north on Dexter past Roy St to Valley St" },
-      { icon: "↱", text: "Turn right onto Valley St heading east" },
-      { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
-      { icon: "↰", text: "Turn left onto Republican St heading east" },
-      { icon: "↱", text: "Turn right onto Minor Ave N heading south" },
-      { icon: "↱", text: "Turn right onto Harrison St heading west" },
-      { icon: "↰", text: "Turn left onto Terry Ave N heading south" },
+      { icon: "▲", text: "Start at Denny Way & Terry Ave N — head west on Denny Way" },
+      { icon: "↱", text: "Turn right onto 9th Ave N heading north" },
+      { icon: "↰", text: "Turn left onto John St heading west" },
+      { icon: "↱", text: "Turn right onto Westlake Ave N heading north" },
       { icon: "↰", text: "Turn left onto Thomas St heading west" },
-      { icon: "↓", text: "Continue to Denny Way" },
-      { icon: "↱", text: "Turn right onto Denny Way heading west" },
+      { icon: "↱", text: "Turn right onto 8th Ave N heading north" },
+      { icon: "↰", text: "Turn left onto Harrison St heading west" },
       { icon: "↱", text: "Turn right onto Dexter Ave N heading north" },
-      { icon: "→", text: "Continue north back to Mercer St" },
-      { icon: "■", text: "Arrive back at Dexter Ave N & Mercer St" },
+      { icon: "→", text: "Continue north on Dexter to Valley St" },
+      { icon: "↱", text: "Turn right onto Valley St heading east" },
+      { icon: "→", text: "Continue east past 8th Ave, Westlake to 9th Ave N" },
+      { icon: "↱", text: "Turn right onto 9th Ave N heading south" },
+      { icon: "↰", text: "Turn left onto Roy St heading east" },
+      { icon: "↰", text: "Turn left onto Pontius Ave N heading north" },
+      { icon: "↱", text: "Turn right onto Valley St heading east" },
+      { icon: "→", text: "Continue east to Fairview Ave N" },
+      { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
+      { icon: "→", text: "Continue south to Harrison St" },
+      { icon: "↱", text: "Turn right onto Harrison St heading west" },
+      { icon: "↰", text: "Turn left onto Yale Ave N heading south" },
+      { icon: "↱", text: "Turn right onto Thomas St heading west" },
+      { icon: "↰", text: "Turn left onto Boren Ave N heading south" },
+      { icon: "↱", text: "Turn right onto John St heading west" },
+      { icon: "↰", text: "Turn left onto Pontius Ave N heading south" },
+      { icon: "→", text: "Continue south to Denny Way" },
+      { icon: "↱", text: "Turn right onto Denny Way heading west" },
+      { icon: "■", text: "Arrive back at Denny Way & Terry Ave N" },
     ],
-    // Route stays on LAND roads only — no lake crossing
+    /*
+      Heart outline traced counterclockwise from bottom point.
+
+      Left side staircase (bottom → top-left):
+        TERRY → 9TH → WESTLAKE → 8TH → DEXTER
+        Each step goes 1 block west + 1 block north.
+
+      Left lobe top: DEXTER → 8TH → WESTLAKE → 9TH along Valley St
+
+      V-notch: drop from Valley to Roy, cross from 9TH → PONTIUS
+
+      Right lobe top: PONTIUS → FAIRVIEW along Valley St
+
+      Right side staircase (top-right → bottom):
+        FAIRVIEW → YALE → BOREN → PONTIUS → TERRY
+        Mirror of left side.
+
+      Both lobes have ~equal width at Valley St:
+        Left:  DEXTER to 9TH  ≈ 380m
+        Right: PONTIUS to FAIRVIEW ≈ 380m
+    */
     coords: [
-      [MERCER, DEXTER],        // Start
-      [ROY, DEXTER],           // N on Dexter
-      [VALLEY, DEXTER],        // N on Dexter
-      [VALLEY, NINTH],         // E on Valley
-      [VALLEY, TERRY],         // E on Valley
-      [VALLEY, FAIRVIEW],      // E on Valley
-      [ROY, FAIRVIEW],         // S on Fairview
-      [MERCER, FAIRVIEW],      // S on Fairview
-      [REPUBLICAN, FAIRVIEW],  // S
-      [REPUBLICAN, MINOR],     // E on Republican
-      [HARRISON, MINOR],       // S on Minor
-      [HARRISON, FAIRVIEW],    // W on Harrison
-      [HARRISON, TERRY],       // W on Harrison
-      [THOMAS, TERRY],         // S on Terry
-      [THOMAS, PONTIUS],       // W on Thomas
-      [JOHN, PONTIUS],         // S
-      [JOHN, WESTLAKE],        // W
-      [DENNY, WESTLAKE],       // S to Denny
+      // Bottom point
+      [DENNY, TERRY],          // Start — bottom center
+
+      // Left staircase (widening upward)
       [DENNY, NINTH],          // W on Denny
-      [DENNY, DEXTER],         // W on Denny
-      [JOHN, DEXTER],          // N on Dexter
-      [THOMAS, DEXTER],        // N
-      [HARRISON, DEXTER],      // N
-      [REPUBLICAN, DEXTER],    // N
-      [MERCER, DEXTER],        // Finish
+      [JOHN, NINTH],           // N on 9th
+      [JOHN, WESTLAKE],        // W on John
+      [THOMAS, WESTLAKE],      // N on Westlake
+      [THOMAS, EIGHTH],        // W on Thomas
+      [HARRISON, EIGHTH],      // N on 8th
+      [HARRISON, DEXTER],      // W on Harrison
+
+      // Left edge going up to top
+      [VALLEY, DEXTER],        // N on Dexter (4 blocks to Valley)
+
+      // Left lobe top
+      [VALLEY, EIGHTH],        // E on Valley
+      [VALLEY, WESTLAKE],      // E on Valley
+      [VALLEY, NINTH],         // E on Valley — inner left
+
+      // V-notch between lobes
+      [ROY, NINTH],            // S on 9th — drop into V
+      [ROY, PONTIUS],          // E on Roy — cross V bottom
+
+      // Right lobe
+      [VALLEY, PONTIUS],       // N on Pontius — back up
+      [VALLEY, FAIRVIEW],      // E on Valley — top right
+
+      // Right edge going down
+      [HARRISON, FAIRVIEW],    // S on Fairview (4 blocks to Harrison)
+
+      // Right staircase (narrowing downward)
+      [HARRISON, YALE],        // W on Harrison
+      [THOMAS, YALE],          // S on Yale
+      [THOMAS, BOREN],         // W on Thomas
+      [JOHN, BOREN],           // S on Boren
+      [JOHN, PONTIUS],         // W on John
+      [DENNY, PONTIUS],        // S on Pontius
+
+      // Close back to bottom point
+      [DENNY, TERRY],          // W on Denny — Finish
     ],
   },
 
   lightning: {
     name: "Lightning",
-    dist: "6.8 mi",
-    time: "~65 min",
-    start: "Westlake Ave N & Aloha St",
-    startCoord: [ALOHA, WESTLAKE],
+    dist: "5.0 mi",
+    time: "~48 min",
+    start: "Dexter Ave N & Aloha St",
+    startCoord: [ALOHA, DEXTER],
     turns: [
-      { icon: "▲", text: "Start at Westlake Ave N & Aloha St — head east on Aloha St" },
+      { icon: "▲", text: "Start at Dexter Ave N & Aloha St — head east on Aloha St" },
       { icon: "→", text: "Continue east on Aloha to Fairview Ave N" },
       { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
-      { icon: "↰", text: "Turn left onto Mercer St heading west" },
-      { icon: "↓", text: "Continue south on Westlake Ave N" },
-      { icon: "→", text: "Continue south to Harrison St" },
-      { icon: "↰", text: "Turn left onto Harrison St heading east" },
-      { icon: "→", text: "Continue east to Fairview Ave N" },
-      { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
-      { icon: "→", text: "Continue south to Denny Way" },
-      { icon: "↱", text: "Turn right onto Denny Way heading west" },
+      { icon: "↰", text: "Turn left onto Valley St heading west" },
+      { icon: "→", text: "Continue west to 9th Ave N" },
+      { icon: "↰", text: "Turn left onto 9th Ave N heading south" },
+      { icon: "↱", text: "Turn right onto Roy St heading west" },
       { icon: "→", text: "Continue west to Dexter Ave N" },
-      { icon: "↱", text: "Turn right onto Dexter Ave N heading north" },
-      { icon: "→", text: "Continue north all the way to Aloha St" },
-      { icon: "↱", text: "Turn right onto Aloha St heading east" },
-      { icon: "■", text: "Arrive back at Westlake Ave N & Aloha St" },
+      { icon: "↰", text: "Turn left onto Dexter Ave N heading south" },
+      { icon: "→", text: "Continue south on Dexter to Denny Way" },
+      { icon: "↰", text: "Turn left onto Denny Way heading east" },
+      { icon: "→", text: "Continue east on Denny to Fairview Ave N" },
+      { icon: "↰", text: "Turn left onto Fairview Ave N heading north" },
+      { icon: "→", text: "Continue north on Fairview to Aloha St" },
+      { icon: "↰", text: "Turn left onto Aloha St heading west" },
+      { icon: "→", text: "Continue west on Aloha to Dexter Ave N" },
+      { icon: "■", text: "Arrive back at Dexter Ave N & Aloha St" },
     ],
+    /*
+      Lightning bolt as a Z-shape with staircase diagonal.
+
+      Top bar:     DEXTER → FAIRVIEW along Aloha (full width)
+      Diagonal:    Staircase from (ALOHA, FAIRVIEW) down to (ROY, DEXTER)
+                   FAI → PONTIUS → 9TH → DEXTER, stepping 1 block south each
+      Left edge:   Straight south on DEXTER from ROY to DENNY
+      Bottom bar:  DEXTER → FAIRVIEW along Denny
+      Return:      North on FAIRVIEW from DENNY to ALOHA
+      Close:       West on ALOHA from FAIRVIEW back to DEXTER
+
+      The diagonal staircase makes the Z look like a lightning bolt ⚡
+    */
     coords: [
-      [ALOHA, WESTLAKE],       // Start
-      [ALOHA, TERRY],          // E on Aloha
-      [ALOHA, FAIRVIEW],       // E on Aloha
-      [ROY, FAIRVIEW],         // S on Fairview
-      [MERCER, FAIRVIEW],      // S on Fairview
-      [MERCER, TERRY],         // W on Mercer (zag left)
-      [MERCER, WESTLAKE],      // W on Mercer
-      [REPUBLICAN, WESTLAKE],  // S on Westlake
-      [HARRISON, WESTLAKE],    // S on Westlake
-      [HARRISON, TERRY],       // E on Harrison (zag right)
-      [HARRISON, FAIRVIEW],    // E on Harrison
-      [THOMAS, FAIRVIEW],      // S on Fairview
-      [JOHN, FAIRVIEW],        // S
-      [DENNY, FAIRVIEW],       // S to Denny
-      [DENNY, TERRY],          // W on Denny
-      [DENNY, WESTLAKE],       // W
-      [DENNY, NINTH],          // W
-      [DENNY, DEXTER],         // W to Dexter
-      [JOHN, DEXTER],          // N on Dexter
-      [THOMAS, DEXTER],        // N
-      [HARRISON, DEXTER],      // N
-      [REPUBLICAN, DEXTER],    // N
-      [MERCER, DEXTER],        // N
-      [ROY, DEXTER],           // N
-      [VALLEY, DEXTER],        // N
-      [ALOHA, DEXTER],         // N to Aloha
-      [ALOHA, NINTH],          // E on Aloha
-      [ALOHA, WESTLAKE],       // Finish
+      // Top bar
+      [ALOHA, DEXTER],         // Start — top-left
+      [ALOHA, FAIRVIEW],       // E on Aloha — top-right
+
+      // Diagonal staircase (upper-right → lower-left)
+      [VALLEY, FAIRVIEW],      // S on Fairview
+      [VALLEY, PONTIUS],       // W on Valley — zag left
+      [ROY, PONTIUS],          // S on Pontius
+      [ROY, NINTH],            // W on Roy — zag left
+      [MERCER, NINTH],         // S on 9th
+      [MERCER, DEXTER],        // W on Mercer — arrive at left edge
+
+      // Left edge going down
+      [REPUBLICAN, DEXTER],    // S on Dexter
+      [HARRISON, DEXTER],      // S
+      [THOMAS, DEXTER],        // S
+      [JOHN, DEXTER],          // S
+      [DENNY, DEXTER],         // S — bottom-left
+
+      // Bottom bar
+      [DENNY, FAIRVIEW],       // E on Denny — bottom-right
+
+      // Return up right side
+      [ALOHA, FAIRVIEW],       // N on Fairview — back to top-right
+
+      // Close loop across top
+      [ALOHA, DEXTER],         // W on Aloha — Finish
     ],
   },
 };


### PR DESCRIPTION
Heart: Staircase outline with two symmetric lobes at Valley St, V-notch at Roy St, and bottom point at Denny/Terry. Left side staircases through 9th→Westlake→8th→Dexter, right mirrors via Yale→Boren→Pontius. Both lobes ~380m wide.

Lightning: Z-shaped bolt with staircase diagonal from upper-right to lower-left (Fairview→Pontius→9th→Dexter), full-width top and bottom bars along Aloha and Denny.

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt