### PR TITLE
Fix routes to stay on land — avoid crossing Lake Union

### DIFF
--- a/lib/routes.js
+++ b/lib/routes.js
@@ -58,27 +58,30 @@ export const SLU_ROADS = {
 export const ROUTES = {
   heart: {
     name: "Heart",
-    dist: "3.6 mi",
-    time: "~35 min",
-    start: "Denny Way & Terry Ave N",
-    startCoord: [DENNY, TERRY],
+    dist: "3.3 mi",
+    time: "~33 min",
+    start: "Denny Way & Pontius Ave N",
+    startCoord: [DENNY, PONTIUS],
     turns: [
-      { icon: "▲", text: "Start at Denny Way & Terry Ave N — head west on Denny Way" },
-      { icon: "↱", text: "Turn right onto 9th Ave N heading north" },
+      { icon: "▲", text: "Start at Denny Way & Pontius Ave N — head west on Denny Way" },
+      { icon: "↱", text: "Turn right onto Terry Ave N heading north" },
       { icon: "↰", text: "Turn left onto John St heading west" },
-      { icon: "↱", text: "Turn right onto Westlake Ave N heading north" },
+      { icon: "↱", text: "Turn right onto 9th Ave N heading north" },
       { icon: "↰", text: "Turn left onto Thomas St heading west" },
-      { icon: "↱", text: "Turn right onto 8th Ave N heading north" },
+      { icon: "↱", text: "Turn right onto Westlake Ave N heading north" },
       { icon: "↰", text: "Turn left onto Harrison St heading west" },
+      { icon: "↱", text: "Turn right onto 8th Ave N heading north" },
+      { icon: "↰", text: "Turn left onto Republican St heading west" },
       { icon: "↱", text: "Turn right onto Dexter Ave N heading north" },
-      { icon: "→", text: "Continue north on Dexter to Valley St" },
-      { icon: "↱", text: "Turn right onto Valley St heading east" },
+      { icon: "↱", text: "Turn right onto Mercer St heading east" },
       { icon: "→", text: "Continue east past 8th Ave, Westlake to 9th Ave N" },
       { icon: "↱", text: "Turn right onto 9th Ave N heading south" },
-      { icon: "↰", text: "Turn left onto Roy St heading east" },
+      { icon: "→", text: "Continue south to Harrison St" },
+      { icon: "↰", text: "Turn left onto Harrison St heading east" },
       { icon: "↰", text: "Turn left onto Pontius Ave N heading north" },
-      { icon: "↱", text: "Turn right onto Valley St heading east" },
-      { icon: "→", text: "Continue east to Fairview Ave N" },
+      { icon: "→", text: "Continue north to Mercer St" },
+      { icon: "↱", text: "Turn right onto Mercer St heading east" },
+      { icon: "→", text: "Continue east past Boren, Yale to Fairview Ave N" },
       { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
       { icon: "→", text: "Continue south to Harrison St" },
       { icon: "↱", text: "Turn right onto Harrison St heading west" },
@@ -87,142 +90,153 @@ export const ROUTES = {
       { icon: "↰", text: "Turn left onto Boren Ave N heading south" },
       { icon: "↱", text: "Turn right onto John St heading west" },
       { icon: "↰", text: "Turn left onto Pontius Ave N heading south" },
-      { icon: "→", text: "Continue south to Denny Way" },
-      { icon: "↱", text: "Turn right onto Denny Way heading west" },
-      { icon: "■", text: "Arrive back at Denny Way & Terry Ave N" },
+      { icon: "■", text: "Arrive back at Denny Way & Pontius Ave N" },
     ],
     /*
-      Heart outline traced counterclockwise from bottom point.
+      Heart outline — ALL ON LAND, lobes at Mercer St level.
+
+      The top is at MERCER (not Valley) so we can use the full
+      east-west grid including FAIRVIEW, YALE, BOREN which are
+      all on land south of Mercer. This avoids Lake Union entirely.
 
       Left side staircase (bottom → top-left):
         TERRY → 9TH → WESTLAKE → 8TH → DEXTER
         Each step goes 1 block west + 1 block north.
 
-      Left lobe top: DEXTER → 8TH → WESTLAKE → 9TH along Valley St
+      Left lobe top: DEXTER → 8TH → WESTLAKE → 9TH along Mercer St
 
-      V-notch: drop from Valley to Roy, cross from 9TH → PONTIUS
+      V-notch: drop from Mercer to Harrison (2 blocks),
+               cross from 9TH → PONTIUS, rise back to Mercer
 
-      Right lobe top: PONTIUS → FAIRVIEW along Valley St
+      Right lobe top: PONTIUS → BOREN → YALE → FAIRVIEW along Mercer St
 
       Right side staircase (top-right → bottom):
-        FAIRVIEW → YALE → BOREN → PONTIUS → TERRY
+        FAIRVIEW → YALE → BOREN → PONTIUS
         Mirror of left side.
 
-      Both lobes have ~equal width at Valley St:
-        Left:  DEXTER to 9TH  ≈ 380m
-        Right: PONTIUS to FAIRVIEW ≈ 380m
+      Both lobes have ~equal width at Mercer St:
+        Left:  DEXTER to 9TH   ≈ 375m
+        Right: PONTIUS to FAIRVIEW ≈ 375m
     */
     coords: [
       // Bottom point
-      [DENNY, TERRY],          // Start — bottom center
+      [DENNY, PONTIUS],          // Start — bottom center
 
-      // Left staircase (widening upward)
-      [DENNY, NINTH],          // W on Denny
-      [JOHN, NINTH],           // N on 9th
-      [JOHN, WESTLAKE],        // W on John
-      [THOMAS, WESTLAKE],      // N on Westlake
-      [THOMAS, EIGHTH],        // W on Thomas
-      [HARRISON, EIGHTH],      // N on 8th
-      [HARRISON, DEXTER],      // W on Harrison
+      // Left staircase (widening upward, 5 steps)
+      [DENNY, TERRY],            // W on Denny
+      [JOHN, TERRY],             // N on Terry
+      [JOHN, NINTH],             // W on John
+      [THOMAS, NINTH],           // N on 9th
+      [THOMAS, WESTLAKE],        // W on Thomas
+      [HARRISON, WESTLAKE],      // N on Westlake
+      [HARRISON, EIGHTH],        // W on Harrison
+      [REPUBLICAN, EIGHTH],      // N on 8th
+      [REPUBLICAN, DEXTER],      // W on Republican
 
-      // Left edge going up to top
-      [VALLEY, DEXTER],        // N on Dexter (4 blocks to Valley)
+      // Left edge going up to lobe top
+      [MERCER, DEXTER],          // N on Dexter — top-left corner
 
-      // Left lobe top
-      [VALLEY, EIGHTH],        // E on Valley
-      [VALLEY, WESTLAKE],      // E on Valley
-      [VALLEY, NINTH],         // E on Valley — inner left
+      // Left lobe top (along Mercer St)
+      [MERCER, EIGHTH],          // E on Mercer
+      [MERCER, WESTLAKE],        // E
+      [MERCER, NINTH],           // E — inner left edge
 
-      // V-notch between lobes
-      [ROY, NINTH],            // S on 9th — drop into V
-      [ROY, PONTIUS],          // E on Roy — cross V bottom
+      // V-notch between lobes (drops 2 blocks to Harrison)
+      [HARRISON, NINTH],         // S on 9th (2 blocks: Mercer→Republican→Harrison)
+      [HARRISON, PONTIUS],       // E on Harrison — cross V bottom
 
-      // Right lobe
-      [VALLEY, PONTIUS],       // N on Pontius — back up
-      [VALLEY, FAIRVIEW],      // E on Valley — top right
+      // Right lobe (rises 2 blocks back to Mercer)
+      [MERCER, PONTIUS],         // N on Pontius (2 blocks back up)
+      [MERCER, BOREN],           // E on Mercer
+      [MERCER, YALE],            // E
+      [MERCER, FAIRVIEW],        // E — outer right edge (on land at Mercer level)
 
       // Right edge going down
-      [HARRISON, FAIRVIEW],    // S on Fairview (4 blocks to Harrison)
+      [HARRISON, FAIRVIEW],      // S on Fairview (2 blocks to Harrison)
 
-      // Right staircase (narrowing downward)
-      [HARRISON, YALE],        // W on Harrison
-      [THOMAS, YALE],          // S on Yale
-      [THOMAS, BOREN],         // W on Thomas
-      [JOHN, BOREN],           // S on Boren
-      [JOHN, PONTIUS],         // W on John
-      [DENNY, PONTIUS],        // S on Pontius
+      // Right staircase (narrowing downward, 3 steps)
+      [HARRISON, YALE],          // W on Harrison
+      [THOMAS, YALE],            // S on Yale
+      [THOMAS, BOREN],           // W on Thomas
+      [JOHN, BOREN],             // S on Boren
+      [JOHN, PONTIUS],           // W on John
 
       // Close back to bottom point
-      [DENNY, TERRY],          // W on Denny — Finish
+      [DENNY, PONTIUS],          // S on Pontius — Finish
     ],
   },
 
   lightning: {
     name: "Lightning",
-    dist: "5.0 mi",
-    time: "~48 min",
+    dist: "4.9 mi",
+    time: "~47 min",
     start: "Dexter Ave N & Aloha St",
     startCoord: [ALOHA, DEXTER],
     turns: [
       { icon: "▲", text: "Start at Dexter Ave N & Aloha St — head east on Aloha St" },
-      { icon: "→", text: "Continue east on Aloha to Fairview Ave N" },
-      { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
-      { icon: "↰", text: "Turn left onto Valley St heading west" },
-      { icon: "→", text: "Continue west to 9th Ave N" },
-      { icon: "↰", text: "Turn left onto 9th Ave N heading south" },
-      { icon: "↱", text: "Turn right onto Roy St heading west" },
+      { icon: "↱", text: "Turn right onto Westlake Ave N heading south" },
+      { icon: "↱", text: "Turn right onto Valley St heading west" },
+      { icon: "↰", text: "Turn left onto Dexter Ave N heading south" },
+      { icon: "↰", text: "Turn left onto Roy St heading east" },
+      { icon: "→", text: "Continue east to Pontius Ave N" },
+      { icon: "↱", text: "Turn right onto Pontius Ave N heading south" },
+      { icon: "↱", text: "Turn right onto Mercer St heading west" },
       { icon: "→", text: "Continue west to Dexter Ave N" },
       { icon: "↰", text: "Turn left onto Dexter Ave N heading south" },
-      { icon: "→", text: "Continue south on Dexter to Denny Way" },
-      { icon: "↰", text: "Turn left onto Denny Way heading east" },
-      { icon: "→", text: "Continue east on Denny to Fairview Ave N" },
-      { icon: "↰", text: "Turn left onto Fairview Ave N heading north" },
-      { icon: "→", text: "Continue north on Fairview to Aloha St" },
-      { icon: "↰", text: "Turn left onto Aloha St heading west" },
-      { icon: "→", text: "Continue west on Aloha to Dexter Ave N" },
+      { icon: "↰", text: "Turn left onto Harrison St heading east" },
+      { icon: "→", text: "Continue east to Fairview Ave N" },
+      { icon: "↱", text: "Turn right onto Fairview Ave N heading south" },
+      { icon: "→", text: "Continue south to Denny Way" },
+      { icon: "↱", text: "Turn right onto Denny Way heading west" },
+      { icon: "→", text: "Continue west to Dexter Ave N" },
+      { icon: "↱", text: "Turn right onto Dexter Ave N heading north" },
+      { icon: "→", text: "Continue north on Dexter to Aloha St" },
       { icon: "■", text: "Arrive back at Dexter Ave N & Aloha St" },
     ],
     /*
-      Lightning bolt as a Z-shape with staircase diagonal.
+      Lightning bolt ⚡ — ALL ON LAND.
 
-      Top bar:     DEXTER → FAIRVIEW along Aloha (full width)
-      Diagonal:    Staircase from (ALOHA, FAIRVIEW) down to (ROY, DEXTER)
-                   FAI → PONTIUS → 9TH → DEXTER, stepping 1 block south each
-      Left edge:   Straight south on DEXTER from ROY to DENNY
-      Bottom bar:  DEXTER → FAIRVIEW along Denny
-      Return:      North on FAIRVIEW from DENNY to ALOHA
-      Close:       West on ALOHA from FAIRVIEW back to DEXTER
+      Expanding zigzag from top to bottom:
+        Narrow top at ALOHA (DEXTER ↔ WESTLAKE, ~300m, on land)
+        Medium middle at ROY (DEXTER ↔ PONTIUS, ~690m, on land)
+        Wide bottom at HARRISON (DEXTER ↔ FAIRVIEW, ~1050m, on land)
 
-      The diagonal staircase makes the Z look like a lightning bolt ⚡
+      The bolt gets wider as it descends, like real lightning.
+      Only uses FAIRVIEW at HARRISON level and below (safely on land).
+      Northern segments stay on DEXTER/WESTLAKE/PONTIUS (west of lake).
+
+      Return path goes south on DEXTER to DENNY, east on DENNY
+      to FAIRVIEW (on land), then north on DEXTER back to ALOHA.
     */
     coords: [
-      // Top bar
-      [ALOHA, DEXTER],         // Start — top-left
-      [ALOHA, FAIRVIEW],       // E on Aloha — top-right
+      // Narrow top bar (on land, west of lake)
+      [ALOHA, DEXTER],           // Start — top-left
+      [ALOHA, WESTLAKE],         // E on Aloha — top-right (narrow)
 
-      // Diagonal staircase (upper-right → lower-left)
-      [VALLEY, FAIRVIEW],      // S on Fairview
-      [VALLEY, PONTIUS],       // W on Valley — zag left
-      [ROY, PONTIUS],          // S on Pontius
-      [ROY, NINTH],            // W on Roy — zag left
-      [MERCER, NINTH],         // S on 9th
-      [MERCER, DEXTER],        // W on Mercer — arrive at left edge
+      // First zigzag down
+      [VALLEY, WESTLAKE],        // S on Westlake
+      [VALLEY, DEXTER],          // W on Valley — zag back left
 
-      // Left edge going down
-      [REPUBLICAN, DEXTER],    // S on Dexter
-      [HARRISON, DEXTER],      // S
-      [THOMAS, DEXTER],        // S
-      [JOHN, DEXTER],          // S
-      [DENNY, DEXTER],         // S — bottom-left
+      // Second zigzag (wider)
+      [ROY, DEXTER],             // S on Dexter
+      [ROY, PONTIUS],            // E on Roy — zag right (medium width)
+
+      // Third zigzag
+      [MERCER, PONTIUS],         // S on Pontius
+      [MERCER, DEXTER],          // W on Mercer — zag back left
+
+      // Fourth zigzag (widest, all on land at Harrison level)
+      [HARRISON, DEXTER],        // S on Dexter
+      [HARRISON, FAIRVIEW],      // E on Harrison — zag right (full width, on land)
+
+      // Bottom stroke
+      [DENNY, FAIRVIEW],         // S on Fairview (on land south of Mercer)
 
       // Bottom bar
-      [DENNY, FAIRVIEW],       // E on Denny — bottom-right
+      [DENNY, DEXTER],           // W on Denny — bottom-left
 
-      // Return up right side
-      [ALOHA, FAIRVIEW],       // N on Fairview — back to top-right
-
-      // Close loop across top
-      [ALOHA, DEXTER],         // W on Aloha — Finish
+      // Return up left side
+      [ALOHA, DEXTER],           // N on Dexter — back to start
     ],
   },
 };


### PR DESCRIPTION
Lowered heart lobes from Valley St to Mercer St where all avenues (including Fairview, Yale, Boren) are on solid ground. Redesigned lightning to only use eastern avenues at Harrison level and below.

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt