### PR TITLE
Ensure shape diversity: one candidate per shape type, relaxed constra…

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -63,32 +63,24 @@ export async function discoverShapes(center, options = {}) {
 
   // Step 3: Fit all shapes
   onProgress("fitting");
-  const allCandidates = [];
+  const bestPerShape = new Map(); // shape key → best candidate
 
   for (const template of SHAPE_LIBRARY) {
     console.log(`[Discovery] Fitting "${template.name}"...`);
-    const fits = fitShape(graph, template, center, 3);
-    allCandidates.push(...fits);
+    const fits = fitShape(graph, template, center, 1); // just the best per shape
+    if (fits.length > 0) {
+      bestPerShape.set(template.key, fits[0]);
+    }
   }
 
-  // Step 4: Rank and deduplicate
-  allCandidates.sort((a, b) => a.score - b.score);
-
-  // Deduplicate: if two candidates of the same shape have similar configs, keep only the best
-  const seen = new Set();
-  const deduped = [];
-  for (const c of allCandidates) {
-    const dedupKey = `${c.shape}_${Math.round(c.config.radius / 100)}_${Math.round(c.config.rotation / 30)}`;
-    if (seen.has(dedupKey)) continue;
-    seen.add(dedupKey);
-    deduped.push(c);
-  }
-
-  const results = deduped.slice(0, maxResults);
+  // Step 4: Collect one candidate per shape, sorted by score
+  const results = [...bestPerShape.values()]
+    .sort((a, b) => a.score - b.score)
+    .slice(0, maxResults);
 
   const elapsed = ((performance.now() - startTime) / 1000).toFixed(1);
   console.log(
-    `[Discovery] Done in ${elapsed}s — ${allCandidates.length} total candidates, returning top ${results.length}`
+    `[Discovery] Done in ${elapsed}s — ${bestPerShape.size} shapes found, returning top ${results.length}`
   );
   for (const r of results) {
     console.log(

--- a/lib/shapeFitter.js
+++ b/lib/shapeFitter.js
@@ -11,13 +11,13 @@ import { transformOutline, pickControlPoints } from "./shapeLibrary.js";
 import { scoreShape } from "./shapeScorer.js";
 
 // Search parameters
-const RADII = [250, 400, 550, 700]; // meters
-const ROTATIONS = [0, 15, 30, 45, 60, 75, 90]; // degrees (only 0-90 due to shape symmetry)
+const RADII = [300, 450, 600, 800]; // meters
+const ROTATIONS = [0, 30, 60, 90]; // degrees (only 0-90 due to shape symmetry)
 const OFFSET_GRID = 3; // 3x3 grid of center offsets
 const OFFSET_FRACTION = 0.25; // offset = radius * this fraction
 
-const MAX_SNAP_DIST = 200; // max distance from ideal point to nearest intersection
-const MAX_DETOUR_RATIO = 3.0; // max route dist / straight-line dist per segment
+const MAX_SNAP_DIST = 300; // max distance from ideal point to nearest intersection
+const MAX_DETOUR_RATIO = 4.0; // max route dist / straight-line dist per segment
 
 /**
  * Fit a single shape template to the graph.


### PR DESCRIPTION
…ints

- Show exactly one best candidate per shape type (heart, lightning, star, loop, diamond) instead of multiple variants of the same shape
- Relax snap distance 200→300m and detour ratio 3→4x to allow complex shapes to fit on more grids
- Increase search radii to [300, 450, 600, 800]m for bigger shapes
- Reduce rotation steps to [0, 30, 60, 90] for speed

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt