### PR TITLE
Day 1 PR 1: Direction-weighted Dijkstra + snap tightening

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -216,9 +216,17 @@ export function nearestNodes(graph, lat, lng, k = 3) {
 /**
  * Find shortest path between two nodes.
  *
+ * @param {Graph} graph
+ * @param {number} startId
+ * @param {number} endId
+ * @param {object} options
+ * @param {number|null} options.desiredBearing - target bearing in degrees (0-360). When set, edges going the wrong direction are penalized.
+ * @param {number} options.directionWeight - how strongly to penalize wrong-direction edges (0 = disabled, 1.5 = strong)
  * @returns {{ path: object[], distance: number, coords: [number,number][] } | null}
  */
-export function dijkstra(graph, startId, endId) {
+export function dijkstra(graph, startId, endId, options = {}) {
+  const { desiredBearing = null, directionWeight = 0 } = options;
+
   if (startId === endId) {
     const n = graph.nodes.get(startId);
     return { path: [], distance: 0, coords: n ? [[n.lat, n.lng]] : [] };
@@ -242,7 +250,20 @@ export function dijkstra(graph, startId, endId) {
     if (!neighbors) continue;
 
     for (const { neighborId, edgeIdx, weight } of neighbors) {
-      const alt = d + weight;
+      let effectiveWeight = weight;
+
+      if (desiredBearing !== null && directionWeight > 0) {
+        const uNode = nodes.get(u);
+        const vNode = nodes.get(neighborId);
+        const edgeBear = bearing([uNode.lat, uNode.lng], [vNode.lat, vNode.lng]);
+        let bearDiff = Math.abs(edgeBear - desiredBearing);
+        if (bearDiff > 180) bearDiff = 360 - bearDiff;
+        // 0 when aligned, directionWeight * distance when opposite
+        const penalty = directionWeight * (1 - Math.cos(bearDiff * Math.PI / 180)) / 2;
+        effectiveWeight += edges[edgeIdx].distance * penalty;
+      }
+
+      const alt = d + effectiveWeight;
       if (alt < (dist.get(neighborId) ?? Infinity)) {
         dist.set(neighborId, alt);
         prev.set(neighborId, { node: u, edgeIdx });

--- a/lib/shapeFitter.js
+++ b/lib/shapeFitter.js
@@ -2,22 +2,23 @@
   Template fitting — overlay shapes on the road graph and find the best fit.
 
   For each shape template, tries multiple positions/scales/rotations,
-  routes between control points using Dijkstra on the local graph,
+  routes between control points using direction-weighted Dijkstra,
   and scores the result.
 */
 
-import { nearestNode, dijkstra, haversine } from "./graph.js";
+import { nearestNode, dijkstra, haversine, bearing } from "./graph.js";
 import { transformOutline, pickControlPoints } from "./shapeLibrary.js";
 import { scoreShape } from "./shapeScorer.js";
 
 // Search parameters — designed for large GPS art spanning 20-40+ blocks
-const RADII = [800, 1100, 1400, 1700, 2000]; // meters (much bigger for real GPS art scale)
+const RADII = [800, 1100, 1400, 1700, 2000]; // meters
 const ROTATIONS = [0, 30, 45, 60, 90]; // degrees
 const OFFSET_GRID = 3; // 3x3 grid of center offsets
 const OFFSET_FRACTION = 0.2; // offset = radius * this fraction
 
-const MAX_SNAP_DIST = 500; // max distance from ideal point to nearest intersection
-const MAX_DETOUR_RATIO = 5.0; // max route dist / straight-line dist per segment
+const MAX_SNAP_DIST = 200; // tight snap: control points must be close to intersections
+const MAX_DETOUR_RATIO = 2.5; // route segments must be fairly direct
+const DIRECTION_WEIGHT = 1.5; // how strongly Dijkstra penalizes wrong-direction edges
 
 /**
  * Fit a single shape template to the graph.
@@ -45,7 +46,6 @@ export function fitShape(graph, template, center, maxResults = 3) {
         const result = trySingleFit(graph, template, offset, radius, rotation);
 
         if (result === null) {
-          // Track why it failed (for logging)
           continue;
         }
         if (result.skipReason === "snap") {
@@ -83,7 +83,8 @@ function trySingleFit(graph, template, center, radius, rotation) {
   const controlGps = pickControlPoints(gpsOutline, template.controlCount);
 
   // 3. Snap each control point to the nearest graph node
-  const snappedNodes = [];
+  //    Track both snapped node and original GPS for direction-aware routing
+  const snappedPairs = []; // [{nodeId, gps: [lat, lng]}]
   for (let i = 0; i < controlGps.length; i++) {
     const [lat, lng] = controlGps[i];
     const { nodeId, dist } = nearestNode(graph, lat, lng);
@@ -93,34 +94,40 @@ function trySingleFit(graph, template, center, radius, rotation) {
     }
 
     // Avoid consecutive duplicate nodes
-    if (snappedNodes.length > 0 && nodeId === snappedNodes[snappedNodes.length - 1]) {
+    if (snappedPairs.length > 0 && nodeId === snappedPairs[snappedPairs.length - 1].nodeId) {
       continue;
     }
-    snappedNodes.push(nodeId);
+    snappedPairs.push({ nodeId, gps: [lat, lng] });
   }
 
-  if (snappedNodes.length < 3) {
+  if (snappedPairs.length < 3) {
     return { skipReason: "snap" };
   }
 
-  // 4. Route between consecutive snapped nodes using Dijkstra
+  // 4. Route between consecutive snapped nodes using direction-weighted Dijkstra
   const allCoords = [];
   let totalDist = 0;
 
-  for (let i = 0; i < snappedNodes.length; i++) {
-    const from = snappedNodes[i];
-    const to = snappedNodes[(i + 1) % snappedNodes.length]; // close the loop
+  for (let i = 0; i < snappedPairs.length; i++) {
+    const fromPair = snappedPairs[i];
+    const toPair = snappedPairs[(i + 1) % snappedPairs.length]; // close the loop
 
-    if (from === to) continue;
+    if (fromPair.nodeId === toPair.nodeId) continue;
 
-    const route = dijkstra(graph, from, to);
+    // Compute desired bearing from the ideal shape control points
+    const desiredBearing = bearing(fromPair.gps, toPair.gps);
+
+    const route = dijkstra(graph, fromPair.nodeId, toPair.nodeId, {
+      desiredBearing,
+      directionWeight: DIRECTION_WEIGHT,
+    });
     if (!route || route.coords.length === 0) {
       return { skipReason: "route" };
     }
 
     // Check for excessive detour
-    const fromNode = graph.nodes.get(from);
-    const toNode = graph.nodes.get(to);
+    const fromNode = graph.nodes.get(fromPair.nodeId);
+    const toNode = graph.nodes.get(toPair.nodeId);
     const straight = haversine([fromNode.lat, fromNode.lng], [toNode.lat, toNode.lng]);
     if (straight > 10 && route.distance / straight > MAX_DETOUR_RATIO) {
       return { skipReason: "route" };


### PR DESCRIPTION
## Summary
- **Direction-weighted Dijkstra**: Routes now follow the shape's intended direction instead of taking shortest-path shortcuts. Each edge gets a bearing penalty proportional to how far off-direction it is (0% for aligned, +75% at 90°, +150% for opposite direction).
- **Tighter snap distance**: 500m → 200m. Control points must be close to actual intersections — eliminates the 5-block drift that was destroying shape silhouettes.
- **Tighter detour ratio**: 5.0 → 2.5. Route segments must be fairly direct — prevents meandering.

## Why this matters
The #1 reason shapes looked unrecognizable: Dijkstra found the *shortest* path between control points, ignoring which direction the shape needed to go. A lightning zigzag would get shortcut into straight lines. A heart curve would cut through the middle. Now the router strongly prefers streets that follow the shape's direction.

## Expected metric impact
| Metric | Before (est.) | After (est.) |
|---|---|---|
| directionScore | ~50% | ~70%+ |
| score | 0.5-0.8 | 0.3-0.5 |
| coverage | 40-60% | 60-75% |

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Shapes visually follow intended direction (especially lightning zigzag, heart curves)
- [ ] No regression in number of shapes found per neighborhood
- [ ] Route segments don't take excessive detours

Part of Day 1 of the shape quality improvement plan (2 PRs/day).

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt)_