### PR TITLE
Day 1 PR 2: Quality metrics engine + reject gate

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -171,7 +171,9 @@ export default function Home() {
               {route.dist}
             </span>
             <span className="text-white/20 text-[10px] font-mono">
-              score: {selectedCandidate.score.toFixed(2)}
+              {selectedCandidate.metrics
+                ? `cov:${(selectedCandidate.metrics.coverage * 100).toFixed(0)}% score:${selectedCandidate.score.toFixed(2)}`
+                : `score:${selectedCandidate.score.toFixed(2)}`}
             </span>
           </div>
         )}

--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -82,12 +82,19 @@ export async function discoverShapes(center, options = {}) {
   console.log(
     `[Discovery] Done in ${elapsed}s — ${bestPerShape.size} shapes found, returning top ${results.length}`
   );
+  // Detailed metrics summary for progress tracking
+  console.log(`[Discovery] ─── Quality Report ───`);
   for (const r of results) {
+    const m = r.metrics || {};
     console.log(
-      `  ${r.icon} ${r.name}: score ${r.score.toFixed(3)}, ${r.coords.length} pts, ` +
-      `${(r.distance / 1609.34).toFixed(1)} mi, radius ${r.config.radius}m, rot ${r.config.rotation}°`
+      `  ${r.icon} ${r.name}: score=${r.score.toFixed(3)} ` +
+      `cov=${((m.coverage || 0) * 100).toFixed(0)}% ` +
+      `rev=${((m.reverseCoverage || 0) * 100).toFixed(0)}% ` +
+      `haus=${(m.hausdorff || 0).toFixed(3)} ` +
+      `${(r.distance / 1609.34).toFixed(1)}mi r=${r.config.radius}m`
     );
   }
+  console.log(`[Discovery] ─── Target: score<0.35 cov>80% haus<0.3 ───`);
 
   onProgress("done");
   return results;

--- a/lib/shapeFitter.js
+++ b/lib/shapeFitter.js
@@ -8,7 +8,7 @@
 
 import { nearestNode, dijkstra, haversine, bearing } from "./graph.js";
 import { transformOutline, pickControlPoints } from "./shapeLibrary.js";
-import { scoreShape } from "./shapeScorer.js";
+import { computeMetrics, passesQualityGate } from "./shapeScorer.js";
 
 // Search parameters — designed for large GPS art spanning 20-40+ blocks
 const RADII = [800, 1100, 1400, 1700, 2000]; // meters
@@ -35,10 +35,10 @@ export function fitShape(graph, template, center, maxResults = 3) {
   let tried = 0;
   let skippedSnap = 0;
   let skippedRoute = 0;
+  let skippedQuality = 0;
 
   for (const radius of RADII) {
     for (const rotation of ROTATIONS) {
-      // Generate offset grid around center
       const offsets = generateOffsets(center, radius * OFFSET_FRACTION, OFFSET_GRID);
 
       for (const offset of offsets) {
@@ -56,6 +56,10 @@ export function fitShape(graph, template, center, maxResults = 3) {
           skippedRoute++;
           continue;
         }
+        if (result.skipReason === "quality") {
+          skippedQuality++;
+          continue;
+        }
 
         candidates.push(result);
       }
@@ -63,12 +67,24 @@ export function fitShape(graph, template, center, maxResults = 3) {
   }
 
   console.log(
-    `[Fitter] ${template.key}: tried ${tried}, skipped snap ${skippedSnap}, ` +
-    `skipped route ${skippedRoute}, valid ${candidates.length}`
+    `[Fitter] ${template.key}: tried ${tried}, snap ${skippedSnap}, ` +
+    `route ${skippedRoute}, quality ${skippedQuality}, valid ${candidates.length}`
   );
 
-  // Sort by score (lower = better) and return top results
+  // Log best candidate metrics for progress tracking
   candidates.sort((a, b) => a.score - b.score);
+  if (candidates.length > 0) {
+    const best = candidates[0];
+    console.log(
+      `[Metrics] ${template.key} best: score=${best.metrics.score.toFixed(3)} ` +
+      `hausdorff=${best.metrics.hausdorff.toFixed(3)} ` +
+      `coverage=${(best.metrics.coverage * 100).toFixed(0)}% ` +
+      `revCoverage=${(best.metrics.reverseCoverage * 100).toFixed(0)}% ` +
+      `turn=${best.metrics.turnScore.toFixed(3)} ` +
+      `r=${best.config.radius}m rot=${best.config.rotation}°`
+    );
+  }
+
   return candidates.slice(0, maxResults);
 }
 
@@ -147,14 +163,19 @@ function trySingleFit(graph, template, center, radius, rotation) {
     return { skipReason: "route" };
   }
 
-  // 6. Score the candidate
-  const score = scoreShape(allCoords, gpsOutline);
+  // 6. Compute quality metrics and apply reject gate
+  const metrics = computeMetrics(allCoords, gpsOutline, radius);
+
+  if (!passesQualityGate(metrics)) {
+    return { skipReason: "quality" };
+  }
 
   return {
     shape: template.key,
     name: template.name,
     icon: template.icon,
-    score,
+    score: metrics.score,
+    metrics,
     coords: allCoords,
     distance: totalDist,
     config: { center, radius, rotation },

--- a/lib/shapeScorer.js
+++ b/lib/shapeScorer.js
@@ -1,49 +1,82 @@
 /*
   Shape scoring — measures how well a candidate route matches a target shape.
 
-  Two complementary metrics:
-  1. Turning function distance — compares the cumulative angle profile
-  2. Hausdorff-like deviation — measures max/avg distance between curves
+  Metrics:
+  1. Turning function distance — compares cumulative angle profiles
+  2. Hausdorff distance — max deviation from route to target (normalized)
+  3. Coverage — % of target outline covered by the route
+  4. Reverse coverage — % of route that stays near the target outline
 
   Combined into a single score: 0.0 = perfect match, 1.0 = no resemblance.
+  Also exports individual metrics for quality tracking.
 */
 
-import { haversine } from "./graph.js";
+import { haversine, bearing } from "./graph.js";
+
+const COVERAGE_THRESHOLD = 150; // meters — a target point is "covered" if route passes within this
 
 /**
- * Score how well a candidate route matches a target shape.
+ * Compute all quality metrics for a candidate route vs target shape.
  *
  * @param {[number,number][]} candidateCoords - actual route [lat,lng] points
  * @param {[number,number][]} targetCoords - ideal shape [lat,lng] points
- * @returns {number} score 0.0 (perfect) to 1.0 (no match)
+ * @param {number} radius - fitting radius in meters (for normalization)
+ * @returns {{score: number, hausdorff: number, coverage: number, reverseCoverage: number, turnScore: number}}
  */
-export function scoreShape(candidateCoords, targetCoords) {
-  if (candidateCoords.length < 3 || targetCoords.length < 3) return 1.0;
+export function computeMetrics(candidateCoords, targetCoords, radius) {
+  if (candidateCoords.length < 3 || targetCoords.length < 3) {
+    return { score: 1.0, hausdorff: 1.0, coverage: 0, reverseCoverage: 0, turnScore: 1.0 };
+  }
 
   const turnScore = turningFunctionDistance(candidateCoords, targetCoords);
-  const devScore = normalizedDeviation(candidateCoords, targetCoords);
+  const { hausdorff, avgDev } = hausdorffMetrics(candidateCoords, targetCoords, radius);
+  const coverage = computeCoverage(candidateCoords, targetCoords);
+  const reverseCoverage = computeCoverage(targetCoords, candidateCoords);
 
-  // Weighted combination
-  return Math.min(1.0, 0.5 * turnScore + 0.5 * devScore);
+  // Weighted score: coverage-heavy (what matters most for visual recognition)
+  const score = Math.min(1.0,
+    0.15 * turnScore +
+    0.25 * hausdorff +
+    0.30 * (1 - coverage) +
+    0.30 * (1 - reverseCoverage)
+  );
+
+  return { score, hausdorff, coverage, reverseCoverage, turnScore };
+}
+
+/**
+ * Score how well a candidate route matches a target shape.
+ * Backward-compatible single-score API.
+ */
+export function scoreShape(candidateCoords, targetCoords, radius = 0) {
+  const metrics = computeMetrics(candidateCoords, targetCoords, radius);
+  return metrics.score;
+}
+
+// ─── Quality gate ───────────────────────────────────────────────────
+
+const SCORE_REJECT = 0.50; // reject candidates scoring worse than this
+const COVERAGE_REJECT = 0.40; // reject if less than 40% of target is covered
+
+/**
+ * Check if a candidate passes the quality gate.
+ */
+export function passesQualityGate(metrics) {
+  if (metrics.score > SCORE_REJECT) return false;
+  if (metrics.coverage < COVERAGE_REJECT) return false;
+  return true;
 }
 
 // ─── Turning function distance ───────────────────────────────────────
 
-/**
- * Compute turning function distance between two closed curves.
- * The turning function maps arc length → cumulative turning angle.
- * Lower = more similar shape.
- */
 function turningFunctionDistance(coords1, coords2) {
   const tf1 = turningFunction(coords1);
   const tf2 = turningFunction(coords2);
 
-  // Resample both to same length
   const n = 64;
   const s1 = resampleTF(tf1, n);
   const s2 = resampleTF(tf2, n);
 
-  // Find best cyclic shift (handles different starting points)
   let bestDist = Infinity;
   for (let shift = 0; shift < n; shift++) {
     let sumSq = 0;
@@ -55,40 +88,34 @@ function turningFunctionDistance(coords1, coords2) {
     if (dist < bestDist) bestDist = dist;
   }
 
-  // Normalize: a distance of ~PI means completely different shapes
   return Math.min(1.0, bestDist / Math.PI);
 }
 
-/**
- * Compute turning function for a closed polyline.
- * Returns array of { arcLen, angle } pairs.
- */
 function turningFunction(coords) {
   const n = coords.length;
   const result = [];
   let cumLen = 0;
   let cumAngle = 0;
+  let prevAngle = 0;
 
   for (let i = 0; i < n - 1; i++) {
-    const dx = coords[(i + 1) % n][1] - coords[i][1]; // lng diff
-    const dy = coords[(i + 1) % n][0] - coords[i][0]; // lat diff
+    const dx = coords[(i + 1) % n][1] - coords[i][1];
+    const dy = coords[(i + 1) % n][0] - coords[i][0];
     const angle = Math.atan2(dy, dx);
 
     if (i > 0) {
       let delta = angle - prevAngle;
-      // Normalize to [-PI, PI]
       while (delta > Math.PI) delta -= 2 * Math.PI;
       while (delta < -Math.PI) delta += 2 * Math.PI;
       cumAngle += delta;
     }
 
-    var prevAngle = angle;
+    prevAngle = angle;
     const segLen = Math.sqrt(dx * dx + dy * dy);
     result.push({ arcLen: cumLen, angle: cumAngle });
     cumLen += segLen;
   }
 
-  // Normalize arc length to [0, 1]
   if (cumLen > 0) {
     for (const r of result) {
       r.arcLen /= cumLen;
@@ -98,9 +125,6 @@ function turningFunction(coords) {
   return result;
 }
 
-/**
- * Resample a turning function to n evenly-spaced points.
- */
 function resampleTF(tf, n) {
   if (tf.length === 0) return new Array(n).fill(0);
 
@@ -125,43 +149,71 @@ function resampleTF(tf, n) {
   return result;
 }
 
-// ─── Deviation scoring ───────────────────────────────────────────────
+// ─── Hausdorff metrics ──────────────────────────────────────────────
 
 /**
- * Compute normalized average deviation between candidate and target.
- * For each point on the candidate, find the closest point on the target.
- * Returns 0.0-1.0 where 0 = perfect overlap.
+ * Compute normalized Hausdorff distance and average deviation.
+ * Hausdorff = max distance from any route point to its nearest target point.
  */
-function normalizedDeviation(candidateCoords, targetCoords) {
-  // Compute the "size" of the target for normalization
-  let targetSize = 0;
-  for (let i = 0; i < targetCoords.length - 1; i++) {
-    targetSize += haversine(targetCoords[i], targetCoords[i + 1]);
-  }
-  if (targetSize < 10) return 1.0;
+function hausdorffMetrics(candidateCoords, targetCoords, radius) {
+  const sampleCount = 48;
+  const cStep = Math.max(1, Math.floor(candidateCoords.length / sampleCount));
+  const tStep = Math.max(1, Math.floor(targetCoords.length / 64));
 
-  // Sample candidate at ~32 evenly-spaced points
-  const sampleCount = 32;
-  const step = Math.max(1, Math.floor(candidateCoords.length / sampleCount));
+  let maxDev = 0;
   let totalDev = 0;
   let count = 0;
 
-  for (let i = 0; i < candidateCoords.length; i += step) {
+  for (let i = 0; i < candidateCoords.length; i += cStep) {
     const cp = candidateCoords[i];
     let minDist = Infinity;
 
-    // Find closest target point (sample target too for speed)
-    const tStep = Math.max(1, Math.floor(targetCoords.length / 48));
     for (let j = 0; j < targetCoords.length; j += tStep) {
       const d = haversine(cp, targetCoords[j]);
       if (d < minDist) minDist = d;
     }
 
+    if (minDist > maxDev) maxDev = minDist;
     totalDev += minDist;
     count++;
   }
 
-  const avgDev = totalDev / count;
-  // Normalize: avgDev of ~targetSize/4 means very distorted
-  return Math.min(1.0, avgDev / (targetSize / 8));
+  // Normalize by radius (or a reasonable default)
+  const norm = radius > 0 ? radius : 1000;
+  return {
+    hausdorff: Math.min(1.0, maxDev / norm),
+    avgDev: count > 0 ? totalDev / count : Infinity,
+  };
+}
+
+// ─── Coverage metrics ───────────────────────────────────────────────
+
+/**
+ * Compute what fraction of sourceCoords has a point in referenceCoords within threshold.
+ * Used bidirectionally:
+ *   coverage = computeCoverage(route, target)       — does route cover the target shape?
+ *   reverseCoverage = computeCoverage(target, route) — does route stay on the target shape?
+ */
+function computeCoverage(sourceCoords, referenceCoords) {
+  const sampleCount = 48;
+  const sStep = Math.max(1, Math.floor(sourceCoords.length / sampleCount));
+  const rStep = Math.max(1, Math.floor(referenceCoords.length / 64));
+
+  let covered = 0;
+  let total = 0;
+
+  for (let i = 0; i < sourceCoords.length; i += sStep) {
+    const sp = sourceCoords[i];
+    let minDist = Infinity;
+
+    for (let j = 0; j < referenceCoords.length; j += rStep) {
+      const d = haversine(sp, referenceCoords[j]);
+      if (d < minDist) minDist = d;
+    }
+
+    if (minDist <= COVERAGE_THRESHOLD) covered++;
+    total++;
+  }
+
+  return total > 0 ? covered / total : 0;
 }


### PR DESCRIPTION
## Summary
- **Quality metrics**: Every candidate now has measurable hausdorff, coverage, reverseCoverage, and turnScore metrics — no more guessing if shapes improved
- **Reject gate**: Candidates with score > 0.50 or coverage < 40% are automatically rejected — stops showing garbage shapes
- **Reweighted scoring**: 15% turn + 25% hausdorff + 30% coverage + 30% reverse coverage (was 50/50 turn+deviation). Coverage matters most for visual recognition.
- **Console quality report**: Logs all metrics + targets after every discovery run so we can track progress

## New scoring formula
```
score = 0.15 * turnScore + 0.25 * hausdorff + 0.30 * (1-coverage) + 0.30 * (1-reverseCoverage)
```

## Quality gate
```
REJECT if score > 0.50
REJECT if coverage < 40%
```

## Target metrics (production-ready)
| Metric | Target |
|---|---|
| score | < 0.35 |
| coverage | > 80% |
| hausdorff | < 0.30 |

## Console output example
```
[Metrics] pixel-heart best: score=0.312 hausdorff=0.245 coverage=72% revCoverage=68% turn=0.189 r=1400m rot=0°
[Discovery] ─── Quality Report ───
  ♥ Heart: score=0.312 cov=72% rev=68% haus=0.245 3.2mi r=1400m
[Discovery] ─── Target: score<0.35 cov>80% haus<0.3 ───
```

## Test plan
- [ ] Build passes
- [ ] Console shows quality report with all metrics
- [ ] Bad shapes are rejected (fewer but higher quality candidates shown)
- [ ] Stacks on PR #24 (direction-weighted Dijkstra)

Day 1 complete — direction-aware routing + measurable quality metrics.

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt)_