### PR TITLE
Day 2 PR 3: Grid orientation detection + intermediate waypoints

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -115,11 +115,14 @@ export function buildGraph(osmData) {
   // Build spatial index
   const spatialIndex = buildSpatialIndex(nodes);
 
+  // Detect dominant grid orientation
+  const gridAngle = detectGridAngle(edges, nodes);
+
   console.log(
-    `[Graph] Built: ${nodes.size} nodes, ${edges.length} edges`
+    `[Graph] Built: ${nodes.size} nodes, ${edges.length} edges, grid angle: ${gridAngle.toFixed(1)}°`
   );
 
-  return { nodes, edges, adjacency, spatialIndex };
+  return { nodes, edges, adjacency, spatialIndex, gridAngle };
 }
 
 // ─── Spatial index ───────────────────────────────────────────────────
@@ -153,6 +156,52 @@ function buildSpatialIndex(nodes) {
   }
 
   return { cells, minLat, minLng, latStep, lngStep };
+}
+
+// ─── Grid orientation detection ─────────────────────────────────────
+
+/**
+ * Detect the dominant grid angle of the road network.
+ * Returns the angle in degrees (0-90) that most road segments align to.
+ *
+ * Method: histogram of edge bearings mod 90° (grids have 4-fold symmetry),
+ * weighted by edge distance. The peak bin is the dominant grid direction.
+ */
+function detectGridAngle(edges, nodes) {
+  const BINS = 90; // 1° resolution
+  const histogram = new Float64Array(BINS);
+
+  for (const edge of edges) {
+    const fromNode = nodes.get(edge.from);
+    const toNode = nodes.get(edge.to);
+    if (!fromNode || !toNode) continue;
+
+    const bear = bearing([fromNode.lat, fromNode.lng], [toNode.lat, toNode.lng]);
+    // Reduce to 0-90° range (grid symmetry: 0°≡90°≡180°≡270°)
+    const reduced = ((bear % 90) + 90) % 90;
+    const bin = Math.min(Math.floor(reduced), BINS - 1);
+    histogram[bin] += edge.distance; // weight by road length
+  }
+
+  // Smooth histogram with a 5° window to handle noise
+  const smoothed = new Float64Array(BINS);
+  for (let i = 0; i < BINS; i++) {
+    for (let d = -2; d <= 2; d++) {
+      smoothed[i] += histogram[((i + d) % BINS + BINS) % BINS];
+    }
+  }
+
+  // Find peak
+  let peakBin = 0;
+  let peakVal = 0;
+  for (let i = 0; i < BINS; i++) {
+    if (smoothed[i] > peakVal) {
+      peakVal = smoothed[i];
+      peakBin = i;
+    }
+  }
+
+  return peakBin;
 }
 
 /**

--- a/lib/shapeFitter.js
+++ b/lib/shapeFitter.js
@@ -4,31 +4,45 @@
   For each shape template, tries multiple positions/scales/rotations,
   routes between control points using direction-weighted Dijkstra,
   and scores the result.
+
+  Key improvements:
+  - Grid-aligned rotations: detects road grid angle and searches around it
+  - Intermediate waypoints: splits long segments to keep route on-shape
+  - Direction-weighted routing: penalizes edges going the wrong direction
 */
 
 import { nearestNode, dijkstra, haversine, bearing } from "./graph.js";
 import { transformOutline, pickControlPoints } from "./shapeLibrary.js";
 import { computeMetrics, passesQualityGate } from "./shapeScorer.js";
 
-// Search parameters — designed for large GPS art spanning 20-40+ blocks
+// Search parameters
 const RADII = [800, 1100, 1400, 1700, 2000]; // meters
-const ROTATIONS = [0, 30, 45, 60, 90]; // degrees
 const OFFSET_GRID = 3; // 3x3 grid of center offsets
-const OFFSET_FRACTION = 0.2; // offset = radius * this fraction
+const OFFSET_FRACTION = 0.2;
 
 const MAX_SNAP_DIST = 200; // tight snap: control points must be close to intersections
 const MAX_DETOUR_RATIO = 2.5; // route segments must be fairly direct
 const DIRECTION_WEIGHT = 1.5; // how strongly Dijkstra penalizes wrong-direction edges
+const MAX_SEGMENT_DIST = 400; // meters — split segments longer than this with intermediate waypoints
+
+/**
+ * Build grid-aligned rotation list from detected grid angle.
+ * Instead of blind 0/30/45/60/90, search tightly around the actual grid.
+ */
+function buildRotations(gridAngle) {
+  const rotations = new Set();
+  // Search around grid-aligned angles (grid repeats every 90°)
+  for (const base of [gridAngle, gridAngle + 45, gridAngle + 90]) {
+    for (const delta of [-10, -5, 0, 5, 10]) {
+      rotations.add(((base + delta) % 360 + 360) % 360);
+    }
+  }
+  return [...rotations];
+}
 
 /**
  * Fit a single shape template to the graph.
  * Returns the top candidates sorted by score (best first).
- *
- * @param {Graph} graph
- * @param {ShapeTemplate} template
- * @param {[number,number]} center - [lat, lng]
- * @param {number} maxResults
- * @returns {Array<{shape: string, score: number, coords: [number,number][], distance: number, config: object}>}
  */
 export function fitShape(graph, template, center, maxResults = 3) {
   const candidates = [];
@@ -37,8 +51,10 @@ export function fitShape(graph, template, center, maxResults = 3) {
   let skippedRoute = 0;
   let skippedQuality = 0;
 
+  const rotations = buildRotations(graph.gridAngle || 0);
+
   for (const radius of RADII) {
-    for (const rotation of ROTATIONS) {
+    for (const rotation of rotations) {
       const offsets = generateOffsets(center, radius * OFFSET_FRACTION, OFFSET_GRID);
 
       for (const offset of offsets) {
@@ -71,7 +87,6 @@ export function fitShape(graph, template, center, maxResults = 3) {
     `route ${skippedRoute}, quality ${skippedQuality}, valid ${candidates.length}`
   );
 
-  // Log best candidate metrics for progress tracking
   candidates.sort((a, b) => a.score - b.score);
   if (candidates.length > 0) {
     const best = candidates[0];
@@ -81,7 +96,7 @@ export function fitShape(graph, template, center, maxResults = 3) {
       `coverage=${(best.metrics.coverage * 100).toFixed(0)}% ` +
       `revCoverage=${(best.metrics.reverseCoverage * 100).toFixed(0)}% ` +
       `turn=${best.metrics.turnScore.toFixed(3)} ` +
-      `r=${best.config.radius}m rot=${best.config.rotation}°`
+      `r=${best.config.radius}m rot=${best.config.rotation.toFixed(0)}°`
     );
   }
 
@@ -99,7 +114,6 @@ function trySingleFit(graph, template, center, radius, rotation) {
   const controlGps = pickControlPoints(gpsOutline, template.controlCount);
 
   // 3. Snap each control point to the nearest graph node
-  //    Track both snapped node and original GPS for direction-aware routing
   const snappedPairs = []; // [{nodeId, gps: [lat, lng]}]
   for (let i = 0; i < controlGps.length; i++) {
     const [lat, lng] = controlGps[i];
@@ -109,7 +123,6 @@ function trySingleFit(graph, template, center, radius, rotation) {
       return { skipReason: "snap" };
     }
 
-    // Avoid consecutive duplicate nodes
     if (snappedPairs.length > 0 && nodeId === snappedPairs[snappedPairs.length - 1].nodeId) {
       continue;
     }
@@ -120,42 +133,28 @@ function trySingleFit(graph, template, center, radius, rotation) {
     return { skipReason: "snap" };
   }
 
-  // 4. Route between consecutive snapped nodes using direction-weighted Dijkstra
+  // 4. Route between consecutive snapped nodes
+  //    Split long segments with intermediate waypoints to keep route on-shape
   const allCoords = [];
   let totalDist = 0;
 
   for (let i = 0; i < snappedPairs.length; i++) {
     const fromPair = snappedPairs[i];
-    const toPair = snappedPairs[(i + 1) % snappedPairs.length]; // close the loop
+    const toPair = snappedPairs[(i + 1) % snappedPairs.length];
 
     if (fromPair.nodeId === toPair.nodeId) continue;
 
-    // Compute desired bearing from the ideal shape control points
-    const desiredBearing = bearing(fromPair.gps, toPair.gps);
-
-    const route = dijkstra(graph, fromPair.nodeId, toPair.nodeId, {
-      desiredBearing,
-      directionWeight: DIRECTION_WEIGHT,
-    });
-    if (!route || route.coords.length === 0) {
+    const segResult = routeSegmentWithWaypoints(graph, fromPair, toPair);
+    if (!segResult) {
       return { skipReason: "route" };
     }
 
-    // Check for excessive detour
-    const fromNode = graph.nodes.get(fromPair.nodeId);
-    const toNode = graph.nodes.get(toPair.nodeId);
-    const straight = haversine([fromNode.lat, fromNode.lng], [toNode.lat, toNode.lng]);
-    if (straight > 10 && route.distance / straight > MAX_DETOUR_RATIO) {
-      return { skipReason: "route" };
-    }
-
-    // Stitch coords
     if (allCoords.length === 0) {
-      allCoords.push(...route.coords);
+      allCoords.push(...segResult.coords);
     } else {
-      allCoords.push(...route.coords.slice(1));
+      allCoords.push(...segResult.coords.slice(1));
     }
-    totalDist += route.distance;
+    totalDist += segResult.distance;
   }
 
   // 5. Validate total distance
@@ -180,6 +179,83 @@ function trySingleFit(graph, template, center, radius, rotation) {
     distance: totalDist,
     config: { center, radius, rotation },
   };
+}
+
+/**
+ * Route between two snapped pairs, adding intermediate waypoints on long segments.
+ * This prevents Dijkstra from taking shortcuts when control points are far apart.
+ */
+function routeSegmentWithWaypoints(graph, fromPair, toPair) {
+  const straight = haversine(fromPair.gps, toPair.gps);
+
+  // Short segment — route directly
+  if (straight <= MAX_SEGMENT_DIST) {
+    return routeDirected(graph, fromPair, toPair);
+  }
+
+  // Long segment — add intermediate waypoints along the ideal line
+  const numWaypoints = Math.min(4, Math.floor(straight / MAX_SEGMENT_DIST));
+  const waypoints = [fromPair];
+
+  for (let w = 1; w <= numWaypoints; w++) {
+    const frac = w / (numWaypoints + 1);
+    const midLat = fromPair.gps[0] + frac * (toPair.gps[0] - fromPair.gps[0]);
+    const midLng = fromPair.gps[1] + frac * (toPair.gps[1] - fromPair.gps[1]);
+    const { nodeId, dist } = nearestNode(graph, midLat, midLng);
+
+    if (nodeId === null || dist > MAX_SNAP_DIST * 1.5) continue;
+
+    const last = waypoints[waypoints.length - 1];
+    if (nodeId !== last.nodeId) {
+      waypoints.push({ nodeId, gps: [midLat, midLng] });
+    }
+  }
+
+  waypoints.push(toPair);
+
+  // Route through waypoint chain
+  const allCoords = [];
+  let totalDist = 0;
+
+  for (let i = 0; i < waypoints.length - 1; i++) {
+    const result = routeDirected(graph, waypoints[i], waypoints[i + 1]);
+    if (!result) return null;
+
+    if (allCoords.length === 0) {
+      allCoords.push(...result.coords);
+    } else {
+      allCoords.push(...result.coords.slice(1));
+    }
+    totalDist += result.distance;
+  }
+
+  return { coords: allCoords, distance: totalDist };
+}
+
+/**
+ * Route between two pairs using direction-weighted Dijkstra.
+ */
+function routeDirected(graph, fromPair, toPair) {
+  if (fromPair.nodeId === toPair.nodeId) return { coords: [], distance: 0 };
+
+  const desiredBearing = bearing(fromPair.gps, toPair.gps);
+
+  const route = dijkstra(graph, fromPair.nodeId, toPair.nodeId, {
+    desiredBearing,
+    directionWeight: DIRECTION_WEIGHT,
+  });
+
+  if (!route || route.coords.length === 0) return null;
+
+  // Check for excessive detour
+  const fromNode = graph.nodes.get(fromPair.nodeId);
+  const toNode = graph.nodes.get(toPair.nodeId);
+  const straight = haversine([fromNode.lat, fromNode.lng], [toNode.lat, toNode.lng]);
+  if (straight > 10 && route.distance / straight > MAX_DETOUR_RATIO) {
+    return null;
+  }
+
+  return route;
 }
 
 /**


### PR DESCRIPTION
## Summary
- **Grid angle detection**: Analyzes road bearing histogram to find dominant grid orientation. Shape rotations now search ±10° around the detected angle instead of blind 0/30/45/60/90. Pixel-art shapes align to actual streets.
- **Intermediate waypoints**: When control points are >400m apart, inserts up to 4 waypoints along the ideal line. Each snaps to the nearest intersection, creating a chain of short directed routing calls. Prevents large shortcuts on long segments.

## How grid detection works
```
1. For each road edge, compute bearing
2. Reduce to 0-90° (grids have 4-fold symmetry)
3. Build distance-weighted histogram at 1° resolution
4. Smooth with 5° window, find peak → grid angle
5. Search rotations: [angle-10, angle-5, angle, angle+5, angle+10] at 0°, 45°, 90° offsets
```

Seattle SLU grid is ~2° off N/S — shapes now automatically align to this.

## How intermediate waypoints work
```
Before: A ──────────────────────── B  (Dijkstra shortcuts through middle)
After:  A ────── W1 ────── W2 ────── B  (stays on ideal path)
```
Each waypoint snaps to nearest intersection (within 300m). If no intersection found, that waypoint is skipped gracefully.

## Expected metric impact
| Metric | Before (est.) | After (est.) |
|---|---|---|
| coverage | 60-75% | 70-85% |
| reverseCoverage | 55-70% | 65-80% |
| score | 0.3-0.5 | 0.2-0.4 |

## Test plan
- [ ] Build passes
- [ ] Console logs detected grid angle (should be ~0-5° for Seattle)
- [ ] Pixel-art shapes (heart, cross, arrow) have clean staircase edges aligned to streets
- [ ] Long segments no longer cut through the middle of shapes

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt)_