### PR TITLE
Day 2 PR 4: Segment direction validation + self-intersection detection

### DIFF
--- a/lib/discovery.js
+++ b/lib/discovery.js
@@ -91,10 +91,12 @@ export async function discoverShapes(center, options = {}) {
       `cov=${((m.coverage || 0) * 100).toFixed(0)}% ` +
       `rev=${((m.reverseCoverage || 0) * 100).toFixed(0)}% ` +
       `haus=${(m.hausdorff || 0).toFixed(3)} ` +
+      `dir=${((m.directionFidelity || 0) * 100).toFixed(0)}% ` +
+      `cross=${m.selfIntersections || 0} ` +
       `${(r.distance / 1609.34).toFixed(1)}mi r=${r.config.radius}m`
     );
   }
-  console.log(`[Discovery] ─── Target: score<0.35 cov>80% haus<0.3 ───`);
+  console.log(`[Discovery] ─── Target: score<0.35 cov>80% haus<0.3 dir>70% cross<3 ───`);
 
   onProgress("done");
   return results;

--- a/lib/shapeFitter.js
+++ b/lib/shapeFitter.js
@@ -92,10 +92,11 @@ export function fitShape(graph, template, center, maxResults = 3) {
     const best = candidates[0];
     console.log(
       `[Metrics] ${template.key} best: score=${best.metrics.score.toFixed(3)} ` +
-      `hausdorff=${best.metrics.hausdorff.toFixed(3)} ` +
-      `coverage=${(best.metrics.coverage * 100).toFixed(0)}% ` +
-      `revCoverage=${(best.metrics.reverseCoverage * 100).toFixed(0)}% ` +
-      `turn=${best.metrics.turnScore.toFixed(3)} ` +
+      `haus=${best.metrics.hausdorff.toFixed(3)} ` +
+      `cov=${(best.metrics.coverage * 100).toFixed(0)}% ` +
+      `rev=${(best.metrics.reverseCoverage * 100).toFixed(0)}% ` +
+      `dir=${(best.metrics.directionFidelity * 100).toFixed(0)}% ` +
+      `cross=${best.metrics.selfIntersections} ` +
       `r=${best.config.radius}m rot=${best.config.rotation.toFixed(0)}°`
     );
   }
@@ -137,12 +138,15 @@ function trySingleFit(graph, template, center, radius, rotation) {
   //    Split long segments with intermediate waypoints to keep route on-shape
   const allCoords = [];
   let totalDist = 0;
+  const segments = []; // track from/to GPS pairs for direction fidelity scoring
 
   for (let i = 0; i < snappedPairs.length; i++) {
     const fromPair = snappedPairs[i];
     const toPair = snappedPairs[(i + 1) % snappedPairs.length];
 
     if (fromPair.nodeId === toPair.nodeId) continue;
+
+    segments.push({ from: fromPair.gps, to: toPair.gps });
 
     const segResult = routeSegmentWithWaypoints(graph, fromPair, toPair);
     if (!segResult) {
@@ -162,8 +166,8 @@ function trySingleFit(graph, template, center, radius, rotation) {
     return { skipReason: "route" };
   }
 
-  // 6. Compute quality metrics and apply reject gate
-  const metrics = computeMetrics(allCoords, gpsOutline, radius);
+  // 6. Compute quality metrics (with segment data for direction fidelity) and apply reject gate
+  const metrics = computeMetrics(allCoords, gpsOutline, radius, segments);
 
   if (!passesQualityGate(metrics)) {
     return { skipReason: "quality" };

--- a/lib/shapeScorer.js
+++ b/lib/shapeScorer.js
@@ -2,18 +2,19 @@
   Shape scoring — measures how well a candidate route matches a target shape.
 
   Metrics:
-  1. Turning function distance — compares cumulative angle profiles
-  2. Hausdorff distance — max deviation from route to target (normalized)
-  3. Coverage — % of target outline covered by the route
-  4. Reverse coverage — % of route that stays near the target outline
+  1. Hausdorff distance — max deviation from route to target (normalized)
+  2. Coverage — % of target outline covered by the route
+  3. Reverse coverage — % of route that stays near the target outline
+  4. Turning function distance — compares cumulative angle profiles
+  5. Direction fidelity — % of route segments going the right direction
+  6. Self-intersections — number of times route crosses itself
 
   Combined into a single score: 0.0 = perfect match, 1.0 = no resemblance.
-  Also exports individual metrics for quality tracking.
 */
 
 import { haversine, bearing } from "./graph.js";
 
-const COVERAGE_THRESHOLD = 150; // meters — a target point is "covered" if route passes within this
+const COVERAGE_THRESHOLD = 150; // meters
 
 /**
  * Compute all quality metrics for a candidate route vs target shape.
@@ -21,50 +22,179 @@ const COVERAGE_THRESHOLD = 150; // meters — a target point is "covered" if rou
  * @param {[number,number][]} candidateCoords - actual route [lat,lng] points
  * @param {[number,number][]} targetCoords - ideal shape [lat,lng] points
  * @param {number} radius - fitting radius in meters (for normalization)
- * @returns {{score: number, hausdorff: number, coverage: number, reverseCoverage: number, turnScore: number}}
+ * @param {Array<{from: [number,number], to: [number,number]}>} segments - optional segment pairs for direction checking
+ * @returns {object} metrics
  */
-export function computeMetrics(candidateCoords, targetCoords, radius) {
+export function computeMetrics(candidateCoords, targetCoords, radius, segments) {
   if (candidateCoords.length < 3 || targetCoords.length < 3) {
-    return { score: 1.0, hausdorff: 1.0, coverage: 0, reverseCoverage: 0, turnScore: 1.0 };
+    return { score: 1.0, hausdorff: 1.0, coverage: 0, reverseCoverage: 0, turnScore: 1.0, directionFidelity: 0, selfIntersections: 0 };
   }
 
   const turnScore = turningFunctionDistance(candidateCoords, targetCoords);
-  const { hausdorff, avgDev } = hausdorffMetrics(candidateCoords, targetCoords, radius);
+  const { hausdorff } = hausdorffMetrics(candidateCoords, targetCoords, radius);
   const coverage = computeCoverage(candidateCoords, targetCoords);
   const reverseCoverage = computeCoverage(targetCoords, candidateCoords);
+  const directionFidelity = segments ? computeDirectionFidelity(candidateCoords, segments) : 1.0;
+  const selfIntersections = countSelfIntersections(candidateCoords);
 
-  // Weighted score: coverage-heavy (what matters most for visual recognition)
+  // Intersection penalty: each crossing adds to the score
+  const crossPenalty = Math.min(0.3, selfIntersections * 0.05);
+
   const score = Math.min(1.0,
-    0.15 * turnScore +
-    0.25 * hausdorff +
-    0.30 * (1 - coverage) +
-    0.30 * (1 - reverseCoverage)
+    0.10 * turnScore +
+    0.20 * hausdorff +
+    0.25 * (1 - coverage) +
+    0.25 * (1 - reverseCoverage) +
+    0.20 * (1 - directionFidelity) +
+    crossPenalty
   );
 
-  return { score, hausdorff, coverage, reverseCoverage, turnScore };
+  return { score, hausdorff, coverage, reverseCoverage, turnScore, directionFidelity, selfIntersections };
 }
 
 /**
- * Score how well a candidate route matches a target shape.
  * Backward-compatible single-score API.
  */
 export function scoreShape(candidateCoords, targetCoords, radius = 0) {
-  const metrics = computeMetrics(candidateCoords, targetCoords, radius);
-  return metrics.score;
+  return computeMetrics(candidateCoords, targetCoords, radius).score;
 }
 
 // ─── Quality gate ───────────────────────────────────────────────────
 
-const SCORE_REJECT = 0.50; // reject candidates scoring worse than this
-const COVERAGE_REJECT = 0.40; // reject if less than 40% of target is covered
+const SCORE_REJECT = 0.50;
+const COVERAGE_REJECT = 0.40;
+const DIRECTION_REJECT = 0.35; // reject if <35% of segments go the right direction
+const MAX_SELF_INTERSECTIONS = 8;
 
-/**
- * Check if a candidate passes the quality gate.
- */
 export function passesQualityGate(metrics) {
   if (metrics.score > SCORE_REJECT) return false;
   if (metrics.coverage < COVERAGE_REJECT) return false;
+  if (metrics.directionFidelity < DIRECTION_REJECT) return false;
+  if (metrics.selfIntersections > MAX_SELF_INTERSECTIONS) return false;
   return true;
+}
+
+// ─── Direction fidelity ─────────────────────────────────────────────
+
+/**
+ * Measure what fraction of route segments go in the expected direction.
+ *
+ * For each segment (defined by from/to GPS pairs from control points),
+ * check if the actual routed path between them progresses in the expected
+ * bearing (within ±60°).
+ */
+function computeDirectionFidelity(candidateCoords, segments) {
+  if (!segments || segments.length === 0) return 1.0;
+
+  let correct = 0;
+  let total = 0;
+
+  for (const seg of segments) {
+    const expectedBear = bearing(seg.from, seg.to);
+    const { startIdx, endIdx } = findClosestIndices(candidateCoords, seg.from, seg.to);
+
+    if (startIdx === -1 || endIdx === -1 || startIdx === endIdx) continue;
+
+    // Sample a few points along this segment of the route
+    const lo = Math.min(startIdx, endIdx);
+    const hi = Math.max(startIdx, endIdx);
+    const sampleStep = Math.max(1, Math.floor((hi - lo) / 5));
+
+    let segCorrect = 0;
+    let segTotal = 0;
+
+    for (let i = lo; i < hi; i += sampleStep) {
+      const next = Math.min(i + sampleStep, hi);
+      if (next >= candidateCoords.length) break;
+
+      const actualBear = bearing(candidateCoords[i], candidateCoords[next]);
+      let diff = Math.abs(actualBear - expectedBear);
+      if (diff > 180) diff = 360 - diff;
+
+      segTotal++;
+      if (diff <= 60) segCorrect++;
+    }
+
+    total += segTotal;
+    correct += segCorrect;
+  }
+
+  return total > 0 ? correct / total : 1.0;
+}
+
+/**
+ * Find the indices in coords closest to two GPS points.
+ */
+function findClosestIndices(coords, from, to) {
+  let bestFromIdx = -1, bestFromDist = Infinity;
+  let bestToIdx = -1, bestToDist = Infinity;
+  const step = Math.max(1, Math.floor(coords.length / 100));
+
+  for (let i = 0; i < coords.length; i += step) {
+    const dFrom = quickDist(coords[i], from);
+    const dTo = quickDist(coords[i], to);
+    if (dFrom < bestFromDist) { bestFromDist = dFrom; bestFromIdx = i; }
+    if (dTo < bestToDist) { bestToDist = dTo; bestToIdx = i; }
+  }
+
+  return { startIdx: bestFromIdx, endIdx: bestToIdx };
+}
+
+function quickDist([lat1, lng1], [lat2, lng2]) {
+  const dlat = lat1 - lat2;
+  const dlng = (lng1 - lng2) * Math.cos(lat1 * Math.PI / 180);
+  return dlat * dlat + dlng * dlng;
+}
+
+// ─── Self-intersection detection ────────────────────────────────────
+
+/**
+ * Count how many times the route crosses itself.
+ * Samples the route into ~200 segments and checks pairwise.
+ * Skips adjacent segments (they share a point, not a real crossing).
+ */
+function countSelfIntersections(coords) {
+  // Downsample for performance
+  const step = Math.max(1, Math.floor(coords.length / 200));
+  const sampled = [];
+  for (let i = 0; i < coords.length; i += step) {
+    sampled.push(coords[i]);
+  }
+
+  let crossings = 0;
+  for (let i = 0; i < sampled.length - 1; i++) {
+    // Only check segments that are at least 3 apart (skip adjacent)
+    for (let j = i + 3; j < sampled.length - 1; j++) {
+      if (segmentsIntersect(
+        sampled[i], sampled[i + 1],
+        sampled[j], sampled[j + 1]
+      )) {
+        crossings++;
+      }
+    }
+    // Early exit — if there are many crossings, no need to count all
+    if (crossings > 15) return crossings;
+  }
+
+  return crossings;
+}
+
+function segmentsIntersect([ax, ay], [bx, by], [cx, cy], [dx, dy]) {
+  const d1 = cross(cx, cy, dx, dy, ax, ay);
+  const d2 = cross(cx, cy, dx, dy, bx, by);
+  const d3 = cross(ax, ay, bx, by, cx, cy);
+  const d4 = cross(ax, ay, bx, by, dx, dy);
+
+  if (((d1 > 0 && d2 < 0) || (d1 < 0 && d2 > 0)) &&
+      ((d3 > 0 && d4 < 0) || (d3 < 0 && d4 > 0))) {
+    return true;
+  }
+
+  return false;
+}
+
+function cross(ax, ay, bx, by, cx, cy) {
+  return (bx - ax) * (cy - ay) - (by - ay) * (cx - ax);
 }
 
 // ─── Turning function distance ───────────────────────────────────────
@@ -151,10 +281,6 @@ function resampleTF(tf, n) {
 
 // ─── Hausdorff metrics ──────────────────────────────────────────────
 
-/**
- * Compute normalized Hausdorff distance and average deviation.
- * Hausdorff = max distance from any route point to its nearest target point.
- */
 function hausdorffMetrics(candidateCoords, targetCoords, radius) {
   const sampleCount = 48;
   const cStep = Math.max(1, Math.floor(candidateCoords.length / sampleCount));
@@ -178,7 +304,6 @@ function hausdorffMetrics(candidateCoords, targetCoords, radius) {
     count++;
   }
 
-  // Normalize by radius (or a reasonable default)
   const norm = radius > 0 ? radius : 1000;
   return {
     hausdorff: Math.min(1.0, maxDev / norm),
@@ -188,12 +313,6 @@ function hausdorffMetrics(candidateCoords, targetCoords, radius) {
 
 // ─── Coverage metrics ───────────────────────────────────────────────
 
-/**
- * Compute what fraction of sourceCoords has a point in referenceCoords within threshold.
- * Used bidirectionally:
- *   coverage = computeCoverage(route, target)       — does route cover the target shape?
- *   reverseCoverage = computeCoverage(target, route) — does route stay on the target shape?
- */
 function computeCoverage(sourceCoords, referenceCoords) {
   const sampleCount = 48;
   const sStep = Math.max(1, Math.floor(sourceCoords.length / sampleCount));


### PR DESCRIPTION
## Summary
Two new quality metrics that catch shapes passing current gates but looking wrong visually:

- **Direction fidelity**: Checks if each routed segment's actual bearing matches the expected bearing (±60° tolerance). Rejects candidates where <35% of segments go the right direction. Catches routes that connect the dots but go backwards/sideways.
- **Self-intersection detection**: Counts route self-crossings using segment intersection tests (downsampled to ~200 segments for perf). Penalizes score by 0.05 per crossing, rejects at >8 crossings. Clean GPS art shouldn't cross itself.

## Updated scoring formula
```
score = 0.10 * turn + 0.20 * hausdorff + 0.25 * (1-coverage)
      + 0.25 * (1-reverseCoverage) + 0.20 * (1-directionFidelity)
      + min(0.3, selfIntersections * 0.05)
```

## Updated quality gate
```
REJECT if score > 0.50
REJECT if coverage < 40%
REJECT if directionFidelity < 35%
REJECT if selfIntersections > 8
```

## Updated console quality report
```
[Discovery] ─── Quality Report ───
  ♥ Heart: score=0.285 cov=75% rev=70% haus=0.220 dir=82% cross=1 3.2mi r=1400m
[Discovery] ─── Target: score<0.35 cov>80% haus<0.3 dir>70% cross<3 ───
```

## Test plan
- [ ] Build passes
- [ ] Shapes with many self-crossings are rejected
- [ ] Shapes where segments go the wrong direction are rejected
- [ ] Remaining candidates look visually cleaner
- [ ] Console shows dir% and cross count in quality report

## Cumulative PRs
| PR | Change | Metric |
|---|---|---|
| #24 | Direction-weighted Dijkstra | Routes follow shape direction |
| #25 | Quality metrics + reject gate | Bad shapes filtered |
| #26 | Grid detection + waypoints | Shapes align to streets |
| This | Direction + intersection validation | Wrong-direction and tangled shapes filtered |

https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGAjn5yiG3u8jMnmHpssgt)_